### PR TITLE
Change address of protoc-gen-validate repo

### DIFF
--- a/grpc-example/Dockerfile
+++ b/grpc-example/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.10.3-alpine3.8
 RUN apk add make git openssl && rm /var/cache/apk/*
 
 # envoy control-plane dependencies.
-RUN go get github.com/lyft/protoc-gen-validate
+RUN go get github.com/envoyproxy/protoc-gen-validate
 RUN go get github.com/envoyproxy/go-control-plane/envoy/type
 RUN go get github.com/envoyproxy/go-control-plane/envoy/api/v2/core
 RUN go get github.com/gogo/googleapis/google/rpc

--- a/grpc-example/envoy/api/v2/auth/cert.pb.go
+++ b/grpc-example/envoy/api/v2/auth/cert.pb.go
@@ -26,7 +26,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_core2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/cds.pb.go
+++ b/grpc-example/envoy/api/v2/cds.pb.go
@@ -43,7 +43,7 @@ import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf4 "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/api/v2/cluster/outlier_detection.pb.go
+++ b/grpc-example/envoy/api/v2/cluster/outlier_detection.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import google_protobuf4 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/core/address.pb.go
+++ b/grpc-example/envoy/api/v2/core/address.pb.go
@@ -49,7 +49,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/core/base.pb.go
+++ b/grpc-example/envoy/api/v2/core/base.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 

--- a/grpc-example/envoy/api/v2/core/config_source.pb.go
+++ b/grpc-example/envoy/api/v2/core/config_source.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/api/v2/core/grpc_service.pb.go
+++ b/grpc-example/envoy/api/v2/core/grpc_service.pb.go
@@ -10,7 +10,7 @@ import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf4 "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf6 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/core/http_uri.pb.go
+++ b/grpc-example/envoy/api/v2/core/http_uri.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/gogoproto"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import time "time"
 

--- a/grpc-example/envoy/api/v2/core/protocol.pb.go
+++ b/grpc-example/envoy/api/v2/core/protocol.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/api/v2/eds.pb.go
+++ b/grpc-example/envoy/api/v2/eds.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 import _ "github.com/gogo/googleapis/google/api"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 import google_protobuf2 "github.com/gogo/protobuf/types"
 

--- a/grpc-example/envoy/api/v2/endpoint/endpoint.pb.go
+++ b/grpc-example/envoy/api/v2/endpoint/endpoint.pb.go
@@ -26,7 +26,7 @@ import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/c
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_core2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/endpoint/load_report.pb.go
+++ b/grpc-example/envoy/api/v2/endpoint/load_report.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import google_protobuf4 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import binary "encoding/binary"

--- a/grpc-example/envoy/api/v2/lds.pb.go
+++ b/grpc-example/envoy/api/v2/lds.pb.go
@@ -11,7 +11,7 @@ import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/co
 import envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 import _ "github.com/gogo/googleapis/google/api"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import context "golang.org/x/net/context"

--- a/grpc-example/envoy/api/v2/listener/listener.pb.go
+++ b/grpc-example/envoy/api/v2/listener/listener.pb.go
@@ -24,7 +24,7 @@ import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/co
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/api/v2/ratelimit/ratelimit.pb.go
+++ b/grpc-example/envoy/api/v2/ratelimit/ratelimit.pb.go
@@ -15,7 +15,7 @@ package ratelimit
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/api/v2/rds.pb.go
+++ b/grpc-example/envoy/api/v2/rds.pb.go
@@ -10,7 +10,7 @@ import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/co
 import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 import _ "github.com/gogo/googleapis/google/api"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import context "golang.org/x/net/context"

--- a/grpc-example/envoy/api/v2/route/route.pb.go
+++ b/grpc-example/envoy/api/v2/route/route.pb.go
@@ -33,7 +33,7 @@ import google_protobuf "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/accesslog/v2/als.pb.go
+++ b/grpc-example/envoy/config/accesslog/v2/als.pb.go
@@ -20,7 +20,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/accesslog/v2/file.pb.go
+++ b/grpc-example/envoy/config/accesslog/v2/file.pb.go
@@ -6,7 +6,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 
 import io "io"

--- a/grpc-example/envoy/config/bootstrap/v2/bootstrap.pb.go
+++ b/grpc-example/envoy/config/bootstrap/v2/bootstrap.pb.go
@@ -30,7 +30,7 @@ import envoy_config_metrics_v2 "github.com/envoyproxy/go-control-plane/envoy/con
 import envoy_config_overload_v2alpha "github.com/envoyproxy/go-control-plane/envoy/config/overload/v2alpha"
 import envoy_config_ratelimit_v2 "github.com/envoyproxy/go-control-plane/envoy/config/ratelimit/v2"
 import google_protobuf4 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/accesslog/v2/accesslog.pb.go
+++ b/grpc-example/envoy/config/filter/accesslog/v2/accesslog.pb.go
@@ -31,7 +31,7 @@ import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/r
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/fault/v2/fault.pb.go
+++ b/grpc-example/envoy/config/filter/fault/v2/fault.pb.go
@@ -17,7 +17,7 @@ import fmt "fmt"
 import math "math"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/http/buffer/v2/buffer.pb.go
+++ b/grpc-example/envoy/config/filter/http/buffer/v2/buffer.pb.go
@@ -18,7 +18,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.pb.go
+++ b/grpc-example/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.pb.go
@@ -21,7 +21,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_core2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/fault/v2/fault.pb.go
+++ b/grpc-example/envoy/config/filter/http/fault/v2/fault.pb.go
@@ -19,7 +19,7 @@ import math "math"
 import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 import envoy_config_filter_fault_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/fault/v2"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/gzip/v2/gzip.pb.go
+++ b/grpc-example/envoy/config/filter/http/gzip/v2/gzip.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import google_protobuf "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.pb.go
+++ b/grpc-example/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.pb.go
@@ -15,7 +15,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/health_check/v2/health_check.pb.go
+++ b/grpc-example/envoy/config/filter/http/health_check/v2/health_check.pb.go
@@ -19,7 +19,7 @@ import _ "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.go
+++ b/grpc-example/envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.go
@@ -17,7 +17,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/jwt_authn/v2alpha/config.pb.go
+++ b/grpc-example/envoy/config/filter/http/jwt_authn/v2alpha/config.pb.go
@@ -29,7 +29,7 @@ import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/r
 import google_protobuf4 "github.com/gogo/protobuf/types"
 import google_protobuf6 "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/lua/v2/lua.pb.go
+++ b/grpc-example/envoy/config/filter/http/lua/v2/lua.pb.go
@@ -15,7 +15,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/http/rate_limit/v2/rate_limit.pb.go
+++ b/grpc-example/envoy/config/filter/http/rate_limit/v2/rate_limit.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/http/rbac/v2/rbac.pb.go
+++ b/grpc-example/envoy/config/filter/http/rbac/v2/rbac.pb.go
@@ -17,7 +17,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_config_rbac_v2alpha "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/config/filter/http/squash/v2/squash.pb.go
+++ b/grpc-example/envoy/config/filter/http/squash/v2/squash.pb.go
@@ -17,7 +17,7 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/http/transcoder/v2/transcoder.pb.go
+++ b/grpc-example/envoy/config/filter/http/transcoder/v2/transcoder.pb.go
@@ -15,7 +15,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.pb.go
+++ b/grpc-example/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.pb.go
@@ -17,7 +17,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.pb.go
+++ b/grpc-example/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.pb.go
@@ -15,7 +15,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/network/ext_authz/v2/ext_authz.pb.go
+++ b/grpc-example/envoy/config/filter/network/ext_authz/v2/ext_authz.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
+++ b/grpc-example/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
@@ -26,7 +26,7 @@ import google_protobuf "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.pb.go
+++ b/grpc-example/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_config_filter_fault_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/fault/v2"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/filter/network/rate_limit/v2/rate_limit.pb.go
+++ b/grpc-example/envoy/config/filter/network/rate_limit/v2/rate_limit.pb.go
@@ -17,7 +17,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_ratelimit "github.com/envoyproxy/go-control-plane/envoy/api/v2/ratelimit"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/network/rbac/v2/rbac.pb.go
+++ b/grpc-example/envoy/config/filter/network/rbac/v2/rbac.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_config_rbac_v2alpha "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.go
+++ b/grpc-example/envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.go
+++ b/grpc-example/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.go
@@ -20,7 +20,7 @@ import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/c
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import google_protobuf4 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.go
+++ b/grpc-example/envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.go
@@ -26,7 +26,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.go
+++ b/grpc-example/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import io "io"

--- a/grpc-example/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.go
+++ b/grpc-example/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/config/metrics/v2/metrics_service.pb.go
+++ b/grpc-example/envoy/config/metrics/v2/metrics_service.pb.go
@@ -24,7 +24,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/metrics/v2/stats.pb.go
+++ b/grpc-example/envoy/config/metrics/v2/stats.pb.go
@@ -11,7 +11,7 @@ import envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/mat
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/overload/v2alpha/overload.pb.go
+++ b/grpc-example/envoy/config/overload/v2alpha/overload.pb.go
@@ -22,7 +22,7 @@ import math "math"
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import binary "encoding/binary"
 

--- a/grpc-example/envoy/config/ratelimit/v2/rls.pb.go
+++ b/grpc-example/envoy/config/ratelimit/v2/rls.pb.go
@@ -16,7 +16,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/rbac/v2alpha/rbac.pb.go
+++ b/grpc-example/envoy/config/rbac/v2alpha/rbac.pb.go
@@ -18,7 +18,7 @@ package v2alpha
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 import envoy_type_matcher3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher"

--- a/grpc-example/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.go
+++ b/grpc-example/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.go
@@ -15,7 +15,7 @@ package v2alpha
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/trace/v2/trace.pb.go
+++ b/grpc-example/envoy/config/trace/v2/trace.pb.go
@@ -24,7 +24,7 @@ import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/c
 import google_protobuf "github.com/gogo/protobuf/types"
 import google_protobuf1 "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/config/transport_socket/alts/v2alpha/alts.pb.go
+++ b/grpc-example/envoy/config/transport_socket/alts/v2alpha/alts.pb.go
@@ -15,7 +15,7 @@ package v2
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/data/accesslog/v2/accesslog.pb.go
+++ b/grpc-example/envoy/data/accesslog/v2/accesslog.pb.go
@@ -27,7 +27,7 @@ import _ "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/types"
 import google_protobuf2 "github.com/gogo/protobuf/types"
 import _ "github.com/gogo/protobuf/gogoproto"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import time "time"
 

--- a/grpc-example/envoy/data/core/v2alpha/health_check_event.pb.go
+++ b/grpc-example/envoy/data/core/v2alpha/health_check_event.pb.go
@@ -19,7 +19,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import _ "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import time "time"

--- a/grpc-example/envoy/service/accesslog/v2/als.pb.go
+++ b/grpc-example/envoy/service/accesslog/v2/als.pb.go
@@ -18,7 +18,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_data_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/service/auth/v2alpha/external_auth.pb.go
+++ b/grpc-example/envoy/service/auth/v2alpha/external_auth.pb.go
@@ -9,7 +9,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_type1 "github.com/envoyproxy/go-control-plane/envoy/type"
 import google_rpc "github.com/gogo/googleapis/google/rpc"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/service/load_stats/v2/lrs.pb.go
+++ b/grpc-example/envoy/service/load_stats/v2/lrs.pb.go
@@ -19,7 +19,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 import google_protobuf4 "github.com/gogo/protobuf/types"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/service/metrics/v2/metrics_service.pb.go
+++ b/grpc-example/envoy/service/metrics/v2/metrics_service.pb.go
@@ -18,7 +18,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import io_prometheus_client "istio.io/gogo-genproto/prometheus"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/service/ratelimit/v2/rls.pb.go
+++ b/grpc-example/envoy/service/ratelimit/v2/rls.pb.go
@@ -18,7 +18,7 @@ import fmt "fmt"
 import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import envoy_api_v2_ratelimit "github.com/envoyproxy/go-control-plane/envoy/api/v2/ratelimit"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/service/trace/v2/trace_service.pb.go
+++ b/grpc-example/envoy/service/trace/v2/trace_service.pb.go
@@ -19,7 +19,7 @@ import math "math"
 import envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 import opencensus_proto_trace "istio.io/gogo-genproto/opencensus/proto/trace"
 import _ "github.com/gogo/googleapis/google/api"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"

--- a/grpc-example/envoy/type/http_status.pb.go
+++ b/grpc-example/envoy/type/http_status.pb.go
@@ -21,7 +21,7 @@ package envoy_type
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/type/matcher/metadata.pb.go
+++ b/grpc-example/envoy/type/matcher/metadata.pb.go
@@ -23,7 +23,7 @@ package matcher
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/type/matcher/number.pb.go
+++ b/grpc-example/envoy/type/matcher/number.pb.go
@@ -7,7 +7,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import binary "encoding/binary"
 

--- a/grpc-example/envoy/type/matcher/string.pb.go
+++ b/grpc-example/envoy/type/matcher/string.pb.go
@@ -6,7 +6,7 @@ package matcher
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/type/matcher/value.pb.go
+++ b/grpc-example/envoy/type/matcher/value.pb.go
@@ -6,7 +6,7 @@ package matcher
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 
 import io "io"
 

--- a/grpc-example/envoy/type/percent.pb.go
+++ b/grpc-example/envoy/type/percent.pb.go
@@ -6,7 +6,7 @@ package envoy_type
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/lyft/protoc-gen-validate/validate"
+import _ "github.com/envoyproxy/protoc-gen-validate/validate"
 import _ "github.com/gogo/protobuf/gogoproto"
 
 import binary "encoding/binary"


### PR DESCRIPTION
Changes github.com/lyft/protoc-gen-validate/validate
to github.com/envoyproxy/protoc-gen-validate/validate
everywhere.
